### PR TITLE
[#2339] Git/cURL without gcc on AIX.

### DIFF
--- a/aix/bootstrap.sh
+++ b/aix/bootstrap.sh
@@ -25,11 +25,8 @@ RPM_DEPS="bash-3.2-1.aix5.2.ppc.rpm \
     vim-common-6.3-1.aix5.1.ppc.rpm \
     vim-enhanced-6.3-1.aix5.1.ppc.rpm \
     make-3.80-1.aix5.1.ppc.rpm \
+    sudo-1.6.9p23-2noldap.aix5.3.ppc.rpm \
     "
-
-# We need sudo -E, thus a newer sudo than the one in the IBM's AIX toolbox.
-SUDO_RPM_FILE="sudo-1.8.10-4.aix53.pam.rpm"
-SUDO_RPM_LINK="ftp://ftp.sudo.ws/pub/sudo/packages/AIX/5.3/${SUDO_RPM_FILE}"
 
 
 
@@ -68,9 +65,6 @@ ftp $IBM_FTP_SERVER
 rpm -i $WGET_RPM_FILE \
     && rm $WGET_RPM_FILE
 
-# For vim-enhanced and sudo we need a bit more space...
-chfs -a size=+10M /opt
-
 # Get the other required rpms from AIX's toolbox.
 for RPM_FILE in $RPM_DEPS; do
     echo "Downloading and installing ${RPM_FILE}..."
@@ -80,10 +74,7 @@ for RPM_FILE in $RPM_DEPS; do
         && rm $RPM_FILE
 done
 
-wget $SUDO_RPM_LINK \
-    && rpm -i $SUDO_RPM_FILE \
-    && rm $SUDO_RPM_FILE \
-    && echo '%staff        ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers \
+echo '%staff        ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers \
     && chmod 440 /etc/sudoers
 
 # Create the new user.

--- a/aix/git.sh
+++ b/aix/git.sh
@@ -1,73 +1,151 @@
 #!/bin/sh
 #
-# Downloads, compiles and installs GIT and cURL as a regular user (eg. chevah),
-# with SUDO rights. Requires wget, gmake, sudo and (optionally) OpenSSL.
+# Downloads, compiles and installs cURL & Git as a user with SUDO rights in AIX.
+# Requires wget, gmake, sudo and (optionally) OpenSSL.
+# It makes use of IBM's XL C compiler, if found. Otherwise, it downloads IBM's
+# GCC RPMs: libgcc and gcc.
+# It also downloads and install the IBM RPMs for coreutils, zlib and zlib-devel.
 # Adds the path to the git binary and other related env vars to its ~/.profile.
-# Installs gcc, coreutils, zlib, zlib-devel RPMs from IBM's AIX Toolbox.
 #
-
-GIT_VERSION="1.9.0"
-# Only selected versions would compile with the AIX Toolbox gcc compiler on AIX 5.3.
-CURL_VERSION="7.19.7"
 
 INSTALL_DIR="/usr/local"
 CURL_CA_DIR="$INSTALL_DIR/etc/curl"
 CURL_CA_FILE="$CURL_CA_DIR/cacert.pem"
+RPM_DEPS="
+    coreutils-5.0-2.aix5.1.ppc.rpm \
+    zlib-1.2.3-4.aix5.2.ppc.rpm \
+    zlib-devel-1.2.3-4.aix5.2.ppc.rpm \
+    "
 
-GIT_DIR=git-${GIT_VERSION}
-GIT_TAR_GZ=${GIT_DIR}.tar.gz
-GIT_REMOTE_ARCHIVE=http://git-core.googlecode.com/files/${GIT_TAR_GZ}
+# Crude test to look for the IBM's compiler.
+/usr/vac/bin/xlc_r -qversion >/dev/null 2>&1
+if [ $? = 0 ]; then
+    export PATH="/usr/vac/bin:${PATH}"
+    export CC="xlc_r"
+    CURL_VERSION="7.42.1"
+    GIT_VERSION="2.3.7"
+else
+    # Couldn't find IBM's XL C compiler, will install and use IBM GCC..."
+    # Beware: Only selected cURL versions compile with the GCC from IBM Toolbox.
+    export CC="gcc"
+    CURL_VERSION="7.19.7"
+    GIT_VERSION="2.3.7"
+    RPM_DEPS="$RPM_DEPS \
+        gcc-4.2.0-3.aix5.3.ppc.rpm \
+        libgcc-4.2.0-3.aix5.3.ppc.rpm \
+        "
+fi
+
+# IBM's AIX Toolbox FTP base location.
+IBM_LINK_BASE="ftp://ftp.software.ibm.com/aix/freeSoftware/aixtoolbox/RPMS/ppc"
+
 CURL_DIR=curl-${CURL_VERSION}
 CURL_TAR_GZ=${CURL_DIR}.tar.gz
 CURL_REMOTE_ARCHIVE=http://ftp.sunet.se/pub/www/utilities/curl/${CURL_TAR_GZ}
 CURL_CA_BUNDLE="http://curl.haxx.se/ca/cacert.pem"
+GIT_DIR=git-${GIT_VERSION}
+GIT_TAR_GZ=${GIT_DIR}.tar.gz
+GIT_REMOTE_ARCHIVE=https://www.kernel.org/pub/software/scm/git/${GIT_TAR_GZ}
 
-# Get build deps from IBM's AIX Toolbox.
-IBM_FTP_LINK_BASE="ftp://ftp.software.ibm.com/aix/freeSoftware/aixtoolbox/RPMS/ppc"
-RPM_DEPS="gcc-4.2.0-3.aix5.3.ppc.rpm \
-          libgcc-4.2.0-3.aix5.3.ppc.rpm \
-          coreutils-5.0-2.aix5.1.ppc.rpm \
-          zlib-1.2.3-4.aix5.2.ppc.rpm \
-          zlib-devel-1.2.3-4.aix5.2.ppc.rpm \
-          "
 # Absolute path to the install binary from the coreutils package.
 INSTALL_SCRIPT="/usr/linux/bin/install"
 LDFLAGS="-L${INSTALL_DIR}/lib -Wl,-blibpath:${INSTALL_DIR}/lib:/usr/lib:/lib"
+CPPFLAGS="${CPPFLAGS} -I$INSTALL_DIR/include/"
 START_FOLDER=`pwd`
 
+
+# Outputs the basename of the RPM when given the complete name of the RPM file.
+get_rpm_name() {
+    local rpm_file_name=$1
+
+    echo $rpm_file_name | grep 'devel-' >/dev/null
+    if [ $? = 0 ]; then
+        digit_to_cut=2
+    else
+        digit_to_cut=1
+    fi
+    echo $rpm_file_name | cut -d '-' -f 1-${digit_to_cut}
+}
+
+# Check existing free space in target partition against required free space.
+extend_partition_as_needed() {
+    local partition_name=$1
+    local mb_of_required_space=$2
+
+    echo "Free space needed on the ${partition_name} partition: \c"
+    echo "${mb_of_required_space} MB"
+    df -m | grep ${partition_name} >/dev/null 2>&1
+    if [ $? != 0 ]; then
+        echo "No ${partition_name} partition found. \c"
+        echo "Checking the root partition..."
+        partition_name='/'
+    else
+        echo "Checking the ${partition_name} partition..."
+    fi
+    mb_of_free_space=`df -m | grep ${partition_name} | head -n 1 \
+            | awk '{print $3}' | cut -d\. -f 1`
+    if [[ ${mb_of_free_space} -lt ${mb_of_required_space} ]]; then
+        mb_of_more_space=`echo ${mb_of_required_space}-${mb_of_free_space} | bc`
+        echo "Insufficient free space on partition ${partition_name}!"
+        echo "Extending ${partition_name} with ${mb_of_more_space} MB..."
+        sudo chfs -a size=+${mb_of_more_space}M ${partition_name}
+    else
+        echo "There seems to be sufficient space on ${partition_name}: \c"
+        echo "${mb_of_free_space} MB."
+    fi
+}
 
 
 #
 # Here we go...
 #
 
-# Delete already existing RPM files and the git build directory.
-echo "Removing already existing git-related files from the current directory..."
-rm -rf $RPM_DEPS $GIT_TAR_GZ $GIT_DIR $CURL_TAR_GZ $CURL_DIR
+for RPM_FILE in $RPM_DEPS; do
+    RPM_BASENAME=`get_rpm_name ${RPM_FILE}`
+    RPM_DEPS_BASENAMES="${RPM_DEPS_BASENAMES} $RPM_BASENAME"
+done
 
-# Some more space is needed in /opt for the RPMS and in /usr for /usr/local/.
-sudo chfs -a size=+50M /opt
-sudo chfs -a size=+150M /usr
+echo "\nThis script will download and install cURL and Git in AIX 5.3 or newer.\n"
+echo "Install directory:    ${INSTALL_DIR}"
+echo "Compiler to use:      ${CC}"
+echo "RPMs needed:         ${RPM_DEPS_BASENAMES}\n"
+
+# Delete already existing files and the git build directory.
+echo "Removing files left over by this script in the current dir, if any..."
+rm -rf $GIT_TAR_GZ $GIT_DIR $CURL_TAR_GZ $CURL_DIR
+
+extend_partition_as_needed /opt 150
+extend_partition_as_needed /usr 100
 
 # Download and install required RPMs.
 for RPM_FILE in $RPM_DEPS; do
-    echo "Downloading and installing ${RPM_FILE}..."
-    RPM_DIR=`echo $RPM_FILE | cut -d\- -f1`
-    if [ $RPM_DIR = "libgcc" ]; then
-        RPM_DIR="gcc"
+    RPM_NAME=`get_rpm_name ${RPM_FILE}`
+    echo "Checking if ${RPM_NAME} is already installed..."
+    RPM_INSTALLED=`rpm -qa | grep ^"${RPM_NAME}-[0-9]"`
+    if [ $? = 0 ]; then
+        echo "${RPM_NAME} RPM already installed: ${RPM_INSTALLED}."
+    else
+        echo "Downloading and installing ${RPM_FILE}..."
+        RPM_DIR=`echo $RPM_FILE | cut -d\- -f1`
+        if [ $RPM_DIR = "libgcc" ]; then
+            RPM_DIR="gcc"
+        fi
+        wget --quiet "$IBM_LINK_BASE"/"$RPM_DIR"/"$RPM_FILE" \
+            && sudo rpm -i $RPM_FILE \
+            && rm $RPM_FILE
     fi
-    wget "$IBM_FTP_LINK_BASE"/"$RPM_DIR"/"$RPM_FILE" \
-        && sudo rpm -i $RPM_FILE \
-        && rm $RPM_FILE
 done
 
 # Get and compile cURL, with custom CA bundle.
 sudo mkdir -p $CURL_CA_DIR
-wget $CURL_CA_BUNDLE -O curl_cacert.pem \
+echo "Downloading curl certs and sources..."
+wget --quiet $CURL_CA_BUNDLE -O curl_cacert.pem \
     && sudo $INSTALL_SCRIPT curl_cacert.pem $CURL_CA_FILE
-wget $CURL_REMOTE_ARCHIVE \
-    && gunzip -c $CURL_TAR_GZ | tar -xvf - \
+wget --quiet $CURL_REMOTE_ARCHIVE \
+    && echo "Extracting the curl sources, please wait..." \
+    && gunzip -c $CURL_TAR_GZ | tar -xf - \
     && cd $CURL_DIR \
+    && echo "Configuring and compiling curl...\n" \
     && ./configure --prefix="$INSTALL_DIR" --with-ca-bundle=${CURL_CA_FILE} \
     && gmake \
     && sudo make install \
@@ -76,15 +154,22 @@ wget $CURL_REMOTE_ARCHIVE \
 
 # Get and compile git.
 export LDFLAGS
-wget $GIT_REMOTE_ARCHIVE \
-    && gunzip -c $GIT_TAR_GZ | tar -xvf - \
+export CPPFLAGS
+export PATH="${PATH}:${INSTALL_DIR}/bin"
+echo "\nDownloading git sources using the newly compiled curl..."
+curl --silent -O $GIT_REMOTE_ARCHIVE \
+    && echo "Extracting git sources, please wait..." \
+    && gunzip -c $GIT_TAR_GZ | tar -xf - \
     && cd $GIT_DIR \
+    && echo "Configuring and compiling git with $INSTALL_DIR as CURLDIR...\n" \
     && CURLDIR="$INSTALL_DIR" ./configure --prefix=${INSTALL_DIR} --without-tcltk \
     && gmake \
     && sudo gmake install INSTALL=${INSTALL_SCRIPT} \
     && cd $START_FOLDER \
     && rm -rf $GIT_DIR $GIT_TAR_GZ
 
+# Add some useful stuff to ~/.profile
+echo "\nAdding git-related stuff to ~/.profile ..."
 if [ -f ~/.profile ]; then
     echo 'alias git-init="git init --template='${INSTALL_DIR}'/share/git-core/templates"'\
         >> ~/.profile
@@ -92,3 +177,5 @@ if [ -f ~/.profile ]; then
         >> ~/.profile
     echo 'export PATH=$PATH:'${INSTALL_DIR}'/bin' >> ~/.profile
 fi
+
+echo "Done!\n"

--- a/aix/git.sh
+++ b/aix/git.sh
@@ -39,13 +39,15 @@ else
         "
 fi
 
+# Avoid HTTPS links here, as the IBM Toolbox's wget doesn't support HTTPS
+# and the newly compiled curl will only support HTTPS if OpenSSL is available.
 CURL_DIR=curl-${CURL_VERSION}
 CURL_TAR_GZ=${CURL_DIR}.tar.gz
 CURL_REMOTE_ARCHIVE=http://ftp.sunet.se/pub/www/utilities/curl/${CURL_TAR_GZ}
 CURL_CA_BUNDLE="http://curl.haxx.se/ca/cacert.pem"
 GIT_DIR=git-${GIT_VERSION}
 GIT_TAR_GZ=${GIT_DIR}.tar.gz
-GIT_REMOTE_ARCHIVE=https://www.kernel.org/pub/software/scm/git/${GIT_TAR_GZ}
+GIT_REMOTE_ARCHIVE=ftp://www.kernel.org/pub/software/scm/git/${GIT_TAR_GZ}
 
 # Absolute path to the "install" binary from the coreutils package.
 INSTALL_SCRIPT="/usr/linux/bin/install"


### PR DESCRIPTION
## Problem?

We should no longer build Git/cURL with gcc on AIX as we now have a license for the IBM's XL C compiler.
## Solution?

Adapt the git bootstrap script to make it use `xlc_r` if found.

Drive-by fix:
- updated bootstrap script to use IBM's `sudo` as we no longer require `sudo -E` and thus a newer version from upstream.
## How to test?

Please review changes.
Run the script on AIX 5.3 and AIX 7.1 with `xlc_r` installed.
Run the script on AIX 5.3 with no `xlc_r`.

reviewer: @adiroiban 
